### PR TITLE
fix: temporary disable whitelist

### DIFF
--- a/src/hooks/useAddressAllowed.tsx
+++ b/src/hooks/useAddressAllowed.tsx
@@ -11,21 +11,8 @@ const TWO_MINUTES = 2 * 60 * 1000;
 export const useAddressAllowed = (address: string): AddressAllowedResult => {
   const [isAllowed, setIsAllowed] = useState(true);
 
-  const screeningUrl = `https://aave.com/addresses/status`;
-  const queryParams = `?address=${address}`;
-
   const getIsAddressAllowed = async () => {
-    if (screeningUrl && address) {
-      try {
-        const response = await fetch(screeningUrl + queryParams);
-        if (response.ok) {
-          const data: { addressAllowed: boolean } = await response.json();
-          setIsAllowed(data.addressAllowed);
-        }
-      } catch (e) {}
-    } else {
-      setIsAllowed(true);
-    }
+    setIsAllowed(true);
   };
 
   usePolling(getIsAddressAllowed, TWO_MINUTES, false, [address]);


### PR DESCRIPTION
## General Changes
- Disable front whitelist restriction


Whitelist call return a 4xx error and even with https://aave-api-v2.aave.com it return a forbidden issue. So I temporary disable whitelist restriction